### PR TITLE
Missing global prototype declaration for the count method

### DIFF
--- a/src/String.ts
+++ b/src/String.ts
@@ -127,6 +127,7 @@ declare global {
 		partition(separator: string): string[];
 		toNumber(): number;
 		toBigInt(): bigint;
+		count(countString: regex | any): number;
 	}
 }
 export {};


### PR DESCRIPTION
# String.ts
```js
count(countString: regex | any): number;
```

~ xnacly